### PR TITLE
catch IOExceptions and raise custom TranscriptsGenerationException

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -292,12 +292,11 @@ def get_video_transcript_data(video_id, language_code):
         try:
             return dict(file_name=video_transcript.filename, content=video_transcript.transcript.file.read())
         except Exception:
-            logger.exception(
-                '[edx-val] Error while retrieving transcript for video=%s -- language_code=%s',
-                video_id,
-                language_code
+            message = (
+                '[edx-val] Error while retrieving transcript for video=%s -- language_code=%s', video_id, language_code
             )
-            raise TranscriptsGenerationException('Error while retrieving transcript')
+            logger.exception(message)
+            raise TranscriptsGenerationException(message)
 
 
 def get_available_transcript_languages(video_id):

--- a/edxval/api.py
+++ b/edxval/api.py
@@ -284,6 +284,8 @@ def get_video_transcript_data(video_id, language_code):
 
     Returns:
         A dict containing transcript file name and its content.
+    Raises:
+        Raises TranscriptsGenerationException if the trasncript data cannot be read.
     """
     video_transcript = VideoTranscript.get_or_none(video_id, language_code)
     if video_transcript:
@@ -295,7 +297,7 @@ def get_video_transcript_data(video_id, language_code):
                 video_id,
                 language_code
             )
-            raise
+            raise TranscriptsGenerationException('Error while retrieving transcript')
 
 
 def get_available_transcript_languages(video_id):


### PR DESCRIPTION
#### What are the relevant tickets?

related to https://github.com/mitodl/edx-platform/issues/104
fixes #1 

#### What does this PR do?

Although `create_transcripts_xml` catches `TranscriptsGenerationException` in order to allow the export to continue, nowhere in the code is this actually implemented. This PR raises `TranscriptsGenerationException` instead of a generic exception in `get_video_transcript_data` so it can be caught and allow the export to continue. 

#### How should this be manually tested?

Follow the steps to reproduce in https://github.com/mitodl/edx-platform/issues/104

Does export to git complete successfully after this change? If there are transcript files missing from the export, we can address that in a separate issue and pull request. 

#### Any background context you want to provide?

I did this really quickly and a) I'm not sure if it actually works and b) the exception message could be clearer. 

