### PR TITLE
Resolve ResourceNotFound error on transcript generation

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -287,6 +287,8 @@ def get_video_transcript_data(video_id, language_code):
 
     Returns:
         A dict containing transcript file name and its content.
+    Raises:
+        Raises TranscriptsGenerationException if the trasncript data cannot be read.
     """
     video_transcript = VideoTranscript.get_or_none(video_id, language_code)
     if video_transcript:
@@ -298,7 +300,7 @@ def get_video_transcript_data(video_id, language_code):
                 video_id,
                 language_code
             )
-            raise
+            raise TranscriptsGenerationException('Error while retrieving transcript')
 
 
 def get_available_transcript_languages(video_id):

--- a/edxval/api.py
+++ b/edxval/api.py
@@ -295,12 +295,11 @@ def get_video_transcript_data(video_id, language_code):
         try:
             return dict(file_name=video_transcript.filename, content=video_transcript.transcript.file.read())
         except Exception:
-            logger.exception(
-                '[edx-val] Error while retrieving transcript for video=%s -- language_code=%s',
-                video_id,
-                language_code
+            message = (
+                '[edx-val] Error while retrieving transcript for video=%s -- language_code=%s', video_id, language_code
             )
-            raise TranscriptsGenerationException('Error while retrieving transcript')
+            logger.exception(message)
+            raise TranscriptsGenerationException(message)
 
 
 def get_available_transcript_languages(video_id):

--- a/edxval/api.py
+++ b/edxval/api.py
@@ -977,8 +977,8 @@ def create_transcripts_xml(video_id, video_el, resource_fs, static_dir):
                 video_id=video_id,
                 language_code=language_code,
                 file_format=file_format,
-                resource_fs=resource_fs.delegate_fs(),
-                static_dir=combine(u'course', static_dir)  # File system should not start from /draft directory.
+                resource_fs=resource_fs,
+                static_dir=static_dir  # File system should not start from /draft directory.
             )
             transcript_files_map[language_code] = transcript_filename
         except TranscriptsGenerationException:


### PR DESCRIPTION
When trying to write out the transcript file a `ResourceNotFound` exception was being raised. This is because the file path that it was attempting to write to was not present. The `delegate_fs` function call resulted in the root path being one level up from the course output directory. In addition, prepending `course` to the static_dir was erroneous, resulting in a double mismatch of the target directory. Using the `resource_fs` directly and removing the `course` path prefix results in a correct target for the transcript file to be written.