### PR TITLE
Updated static_dir definition to use proper path

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -994,12 +994,13 @@ def create_transcripts_xml(video_id, video_el, resource_fs, static_dir):
         file_format = video_transcript.file_format
 
         try:
+            fs = resource_fs.delegate_fs()
             transcript_filename = create_transcript_file(
                 video_id=video_id,
                 language_code=language_code,
                 file_format=file_format,
-                resource_fs=resource_fs.delegate_fs(),
-                static_dir=static_file_dir
+                resource_fs=fs,
+                static_dir=combine(fs.listdir('.')[0], static_dir)  # File system should not start from /draft directory.
             )
             transcript_files_map[language_code] = transcript_filename
         except TranscriptsGenerationException:

--- a/edxval/api.py
+++ b/edxval/api.py
@@ -280,6 +280,8 @@ def get_video_transcript_data(video_id, language_code):
 
     Returns:
         A dict containing transcript file name and its content.
+    Raises:
+        Raises TranscriptsGenerationException if the trasncript data cannot be read.
     """
     video_transcript = VideoTranscript.get_or_none(video_id, language_code)
     if video_transcript:
@@ -291,7 +293,7 @@ def get_video_transcript_data(video_id, language_code):
                 video_id,
                 language_code
             )
-            raise
+            raise TranscriptsGenerationException('Error while retrieving transcript')
 
     return None
 

--- a/edxval/api.py
+++ b/edxval/api.py
@@ -288,12 +288,11 @@ def get_video_transcript_data(video_id, language_code):
         try:
             return dict(file_name=video_transcript.filename, content=video_transcript.transcript.file.read())
         except Exception:
-            logger.exception(
-                '[edx-val] Error while retrieving transcript for video=%s -- language_code=%s',
-                video_id,
-                language_code
+            message = (
+                '[edx-val] Error while retrieving transcript for video=%s -- language_code=%s', video_id, language_code
             )
-            raise TranscriptsGenerationException('Error while retrieving transcript')
+            logger.exception(message)
+            raise TranscriptsGenerationException(message)
 
     return None
 


### PR DESCRIPTION
This addresses the failing transcript generation due to a hardcoded path for the output file as outlined in mitodl/edx-platform#146